### PR TITLE
Hotfix

### DIFF
--- a/src/com/temporaryteam/noticeditor/io/ZipExportStrategy.java
+++ b/src/com/temporaryteam/noticeditor/io/ZipExportStrategy.java
@@ -15,6 +15,7 @@ public class ZipExportStrategy implements ExportStrategy {
 	@Override
 	public void export(File file, NoticeTree notice) {
 		try {
+			if (file.exists()) file.delete();
 			ZipWithIndexFormat.with(file).export(notice);
 		} catch (ZipException | IOException | JSONException e) {
 			throw new ExportException(e);

--- a/src/com/temporaryteam/noticeditor/io/ZipWithIndexFormat.java
+++ b/src/com/temporaryteam/noticeditor/io/ZipWithIndexFormat.java
@@ -100,9 +100,6 @@ public class ZipWithIndexFormat {
 	}
 	
 	private void storeFile(String path, String content) throws IOException, ZipException {
-		if (zip.isValidZipFile() && zip.getFileHeader(path) != null) {
-			zip.removeFile(path);
-		}
 		parameters.setFileNameInZip(path);
 		try (InputStream stream = IOUtil.toStream(content)) {
 			zip.addStream(stream, parameters);

--- a/src/com/temporaryteam/noticeditor/model/NoticeTreeItem.java
+++ b/src/com/temporaryteam/noticeditor/model/NoticeTreeItem.java
@@ -36,6 +36,15 @@ public class NoticeTreeItem extends TreeItem<String> {
 	public NoticeTreeItem(String title) {
 		this(title, null, 0);
 	}
+	
+	/**
+	 * Create leaf node on tree.
+	 * @param title
+	 * @param content 
+	 */
+	public NoticeTreeItem(String title, String content) {
+		this(title, content, STATUS_NORMAL);
+	}
 
 	/**
 	 * Create leaf node on tree.


### PR DESCRIPTION
Вернул конструктор NoticeTreeItem - в тестах использовался.
Перед экспортом в zip, файл теперь удаляется. Изначально я думал оно будет перезаписывать новый zip-файл, оказалось нет, вот приходится удалять.
Изменения @NaikSoftware нормальные, но так при удалении файла создаётся новый временный zip-архив с непонятным именем, и в конце концов оригинальный файл вообще пропал, оставив за собой лишь временный archive.zip953  